### PR TITLE
Redoing layout on dragging end

### DIFF
--- a/src/js/VerovioWorker.js
+++ b/src/js/VerovioWorker.js
@@ -66,6 +66,10 @@ self.addEventListener('message', function (event) {
             vrvToolkit.setOptions(params.options);
             break;
 
+        case "redoLayout":
+           vrvToolkit.redoLayout();
+           break;
+
         case "renderPage":
            renderPage(params.pageIndex, ticket);
            break;

--- a/src/js/VidaView.js
+++ b/src/js/VidaView.js
@@ -310,6 +310,8 @@ export class VidaView
      */
     renderCurrentPage()
     {
+        this.contactWorker('redoLayout', {});
+        // We should check that the highlighted id is still on the same page
         this.contactWorker('renderPage', {pageIndex: this.currentSystem}, this.displayPage);
     }
 


### PR DESCRIPTION
The layout needs to be redone once we have finished dragging. This can change the page distribution, so eventually we need to check that the page index is still correct